### PR TITLE
Add admin role matching via groups

### DIFF
--- a/Template/auth/login.php
+++ b/Template/auth/login.php
@@ -1,5 +1,5 @@
 <ul class="no-bullet">
     <li>
-        <?= $this->url->icon('lock', t('OAuth2 login'), 'OAuthController', 'handler', array('plugin' => 'OAuth2')) ?>
+        <?= $this->url->icon('lock', t('Log in with OCF Account'), 'OAuthController', 'handler', array('plugin' => 'OAuth2')) ?>
     </li>
 </ul>

--- a/Template/config/integration.php
+++ b/Template/config/integration.php
@@ -42,7 +42,13 @@
 
     <?= $this->form->label(t('Groups Key'), 'oauth2_key_groups') ?>
     <?= $this->form->text('oauth2_key_groups', $values) ?>
-    <p class="form-help"><?= t('Leave empty, when no group mapping is wanted') ?></p>
+    <p class="form-help"><?= t('Leave empty when no group mapping is wanted') ?></p>
+
+    <?= $this->form->label(t('Admin Group'), 'oauth2_admin_group') ?>
+    <?= $this->form->text('oauth2_admin_group', $values) ?>
+
+    <?= $this->form->label(t('Manager Group'), 'oauth2_manager_group') ?>
+    <?= $this->form->text('oauth2_manager_group', $values) ?>
 
     <div class="form-actions">
         <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -3,6 +3,7 @@
 namespace Kanboard\Plugin\OAuth2\User;
 
 use Kanboard\Core\Base;
+use Kanboard\Core\Security\Role;                
 use Kanboard\Core\User\UserProviderInterface;
 use Pimple\Container;
 
@@ -114,14 +115,24 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
     /**
      * Get user role
      *
-     * Return an empty string to not override role stored in the database
-     *
      * @access public
      * @return string
      */
     public function getRole()
     {
-        return '';
+        // Init with smallest role
+        $role = Role::APP_USER;         
+        $groupIds = $this->getExternalGroupIds();
+                                             
+        foreach ($groupIds as $groupId) {
+            $groupId = strtolower($groupId);
+            if ($groupId === strtolower(OAUTH_GROUP_ADMIN)) {
+                // Highest role found : we can and we must exit the loop
+                $role = Role::APP_ADMIN;
+                break;
+            }          
+        }                                  
+        return $role;
     }
 
     /**


### PR DESCRIPTION
This allows us to specify ocfroot as the group allowed to administrate kanboard.